### PR TITLE
Update resources list, add cheat sheet, remove book, fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ A curated list of only awesome TinkerPop libraries on Github.
 ## <A NAME="tutorials-and-resources"></A>Tutorials and Resources
 * [Introduction to Gremlin](http://tinkerpop.apache.org/gremlin.html) - Official introduction to the Gremlin language.
 * [Datastax Introduction](https://academy.datastax.com/resources/getting-started-tinkerpop-and-gremlin) - A tutorial provided by Datastax to Gremlin and TinkerPop3.
-* [TinkerPop Book](http://www.tinkerpopbook.com/) - A long promised book for Tinkeprop but never fulfilled until now. You cans till request a notification.
 * [Linux Foundation Presentation](http://events.linuxfoundation.org/sites/events/files/slides/ApacheCon2015TinkerPop3.pdf) - A presentation by Linux Foundation given by David Robinson at IBM aboit Apache TinkerPop3.
 * [Getting Started with TinkerPop](http://tinkerpop.apache.org/docs/current/tutorials/getting-started/) - Learn the basics of getting up and going with TinkerPop.
-* [The Gremlin Console](http://tinkerpop.apache.org/docs/current/tutorials/the-gremlin-console/) - Discusses uses cases of the Gremlin Console and usage patterns.
+* [The Gremlin Console](http://tinkerpop.apache.org/docs/current/tutorials/the-gremlin-console/) - Discusses use cases of the Gremlin Console and usage patterns.
 * [Gremlin Recipes](http://tinkerpop.apache.org/docs/3.2.1-SNAPSHOT/recipes/) - Reference for common traversal patterns and style.
+* [Gremlin Cheat Sheet 101](https://dkuppitz.github.io/gremlin-cheat-sheet/101.html) - Gremlin cheat sheet with examples.
 * [Gremlin Language Variants](http://tinkerpop.apache.org/docs/3.2.1-SNAPSHOT/tutorials/gremlin-language-variants/) - Learn how to embed Gremlin in a host programming language.
 * [SQL2Gremlin](http://sql2gremlin.com/) - Learn Gremlin using typical patterns found when querying data with SQL.
 * [Getting Started with Graph Databases](https://academy.datastax.com/demos/getting-started-graph-databases) - Compares relational databases to graph databases and SQL to Gremlin.


### PR DESCRIPTION
The "Tutorials and Resources" list is updated as follows:
- Add Gremlin Cheat Sheet 101
- Remove TinkerPop Book, as the URL now points to an unrelated personal blog
- Fix typo: "uses cases" -> "use cases"